### PR TITLE
monitoring

### DIFF
--- a/podmonitor.yaml
+++ b/podmonitor.yaml
@@ -1,0 +1,19 @@
+ apiVersion: monitoring.coreos.com/v1
+ kind: PodMonitor
+ metadata:
+   name: spaceborscht-podmonitor
+   namespace: spaceborscht
+   labels:
+     release: kube-prometheus-stack
+ spec:
+   namespaceSelector:
+     matchNames: ["spaceborscht"]
+   selector:
+     matchExpressions:
+       - key: app
+         operator: In
+         values: ["control", "engine", "comms", "telemetry"]
+   podMetricsEndpoints:
+     - port: metrics-port
+       path: /metrics
+       interval: 15s

--- a/values-prometheus.yaml
+++ b/values-prometheus.yaml
@@ -1,0 +1,27 @@
+ alertmanager:
+   enabled: false
+
+ grafana:
+   enabled: false
+
+ prometheus:
+   prometheusSpec:
+     additionalScrapeConfigs:
+       - job_name: 'blackbox'
+         metrics_path: /probe
+         params:
+           module: [http_2xx]
+         static_configs:
+           - targets:
+              - http://control-service.spaceborscht.svc.cluster.local:3000
+              - http://engine-service.spaceborscht.svc.cluster.local:3001
+              - http://telemetry-service.spaceborscht.svc.cluster.local:3002
+              - http://comms-service.spaceborscht.svc.cluster.local:3003
+              - http://frontend-service.spaceborscht.svc.cluster.local:80
+         relabel_configs:
+           - source_labels: [__address__]
+             target_label: __param_target
+           - source_labels: [__param_target]
+             target_label: instance
+           - target_label: __address__
+             replacement: blackbox-exporter-prometheus-blackbox-exporter.spaceborscht.svc.cluster.local:9115


### PR DESCRIPTION
`(up{namespace="spaceborscht", job="spaceborscht/spaceborscht-podmonitor"} == 1)
and on (job, instance) (scrape_samples_scraped{namespace="spaceborscht", job="spaceborscht/spaceborscht-podmonitor"} > 0)`
![podmonitor-spaceborscht](https://github.com/user-attachments/assets/0bb3b0f9-8d35-44c0-8407-2fb4d0a73d94)
